### PR TITLE
Update required(Text,Voice)Permissions to work with discordjs v14

### DIFF
--- a/structures/client.js
+++ b/structures/client.js
@@ -26,16 +26,16 @@ class Bot extends Client {
 		this.player = new Player(this);
 		this.player.use("dodong", extractor);
 		this.requiredVoicePermissions = [
-			"VIEW_CHANNEL",
-			"CONNECT",
-			"SPEAK"
+			"ViewChannel",
+			"Connect",
+			"Speak"
 		];
 		this.requiredTextPermissions = [
-			"VIEW_CHANNEL",
-			"SEND_MESSAGES",
-			"READ_MESSAGE_HISTORY",
-			"ADD_REACTIONS",
-			"EMBED_LINKS"
+			"ViewChannel",
+			"SendMessages",
+			"ReadMessageHistory",
+			"AddReactions",
+			"EmbedLinks"
 		];
 		this.prefix = process.env.PREFIX || config.prefix;
 


### PR DESCRIPTION
This addresses #37 by updating the requiredTextPermissions/requiredVoicePermissions to match the appropriate BitField in disordjs v14.

Breadcrumbs for [name/bit mappings](https://github.com/discordjs/discord-api-types/blob/main/payloads/common.ts)